### PR TITLE
Add pythonocc-core dependency to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,9 @@
     <!-- Icon -->
     <icon>resources/icons/logo.svg</icon>
 
+    <!-- Dependencies -->
+    <depend type="python">pythonocc-core</depend>
+
     <!-- Urls -->
     <url type="repository" branch="main">https://github.com/ryankembrey/FreeCAD-DFM-Workbench</url>
     <url type="documentation">https://ryankembrey.github.io/FreeCAD-DFM-Workbench/</url>


### PR DESCRIPTION
Some builds of FreeCAD don't include `pythonocc` -- in those cases, to make this addon work the Addon Manager should try to install it. Note that it doesn't work *at all* with OCCT8, so any FreeCAD built against that version won't work with this addon right now.